### PR TITLE
Update styles

### DIFF
--- a/about.json
+++ b/about.json
@@ -18,11 +18,11 @@
   "color_schemes": {
     "VS Code for Education - Dark Modern": {
       "primary": "ffffff",
-      "secondary": "2b2b2b",
+      "secondary": "1e1e1e",
       "tertiary": "0078d4",
       "quaternary": "229fff",
-      "header_background": "181818",
-      "header_primary": "cccccc",
+      "header_background": "1e1e1e",
+      "header_primary": "ffffff",
       "highlight": "ffda61",
       "selected": "2c2c2c",
       "hover": "474747",
@@ -45,7 +45,6 @@
       "love": "ff79c6"
     }
   },
-  "modifiers": {
-  },
+  "modifiers": {},
   "learn_more": "https://meta.discourse.org/t/beginners-guide-to-using-discourse-themes/91966"
 }

--- a/stylesheets/fonts.scss
+++ b/stylesheets/fonts.scss
@@ -1,68 +1,66 @@
 @font-face {
-  font-family: "Segoe Sans Display";
-  src: url($ssp-regular);
+  font-family: "Segoe UI", "Segoe UI Web (West European)", -apple-system,
+    BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
 }
 
 @font-face {
-  font-family: "Segoe Sans Display";
-  src: url($ssp-regular);
+  font-family: "Segoe UI", "Segoe UI Web (West European)", -apple-system,
+    BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
   font-style: italic;
 }
 
 @font-face {
-  font-family: "Segoe Sans Display";
-  src: url($ssp-light);
+  font-family: "Segoe UI", "Segoe UI Web (West European)", -apple-system,
+    BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
   font-weight: 300;
 }
 
 @font-face {
-  font-family: "Segoe Sans Display";
-  src: url($ssp-light);
+  font-family: "Segoe UI", "Segoe UI Web (West European)", -apple-system,
+    BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
   font-weight: 300;
   font-style: italic;
 }
 
 @font-face {
-  font-family: "Segoe Sans Display";
-  src: url($ssp-semibold);
+  font-family: "Segoe UI", "Segoe UI Web (West European)", -apple-system,
+    BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
   font-weight: 600;
 }
 
 @font-face {
-  font-family: "Segoe Sans Display";
-  src: url($ssp-semibold);
+  font-family: "Segoe UI", "Segoe UI Web (West European)", -apple-system,
+    BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
   font-weight: 600;
   font-style: italic;
 }
 
 @font-face {
-  font-family: "Segoe Sans Display";
-  src: url($ssp-bold);
+  font-family: "Segoe UI", "Segoe UI Web (West European)", -apple-system,
+    BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
   font-weight: 700;
 }
 
 @font-face {
-  font-family: "Segoe Sans Display";
-  src: url($ssp-bold);
+  font-family: "Segoe UI", "Segoe UI Web (West European)", -apple-system,
+    BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
   font-weight: 700;
   font-style: italic;
 }
 
 @font-face {
-  font-family: "Segoe Sans Display";
-  src: url($ssp-black);
+  font-family: "Segoe UI", "Segoe UI Web (West European)", -apple-system,
+    BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
   font-weight: 900;
 }
 
 @font-face {
-  font-family: "Segoe Sans Display";
-  src: url($ssp-black);
+  font-family: "Segoe UI", "Segoe UI Web (West European)", -apple-system,
+    BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
   font-weight: 900;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Source Code Pro";
-  src: url($scp-regular);
 }
-


### PR DESCRIPTION
This pull request primarily focuses on changes to the visual aspects of the application, with modifications made to color schemes and font families. The most significant changes are in the `about.json` and `stylesheets/fonts.scss` files. 

Color scheme modifications:

* [`about.json`](diffhunk://#diff-646bd422594fa181f6e2fca4e1da7504a5fe35dbfbc8cb11c0b4b47813916086L21-R25): The color scheme "VS Code for Education - Dark Modern" has been updated with new color values for "secondary", "header_background", and "header_primary".

Font family changes:

* [`stylesheets/fonts.scss`](diffhunk://#diff-7a6daed9692563e6ea707a2f681c57eddb596fbb5e193e5ba103003a13d5bd79L2-L68): The font family "Segoe Sans Display" has been replaced with a list of fallback fonts, including "Segoe UI", "Segoe UI Web (West European)", "-apple-system", "BlinkMacSystemFont", "Roboto", "Helvetica Neue", and "sans-serif". This change has been applied to all font-face declarations in the file.

Minor changes:

* [`about.json`](diffhunk://#diff-646bd422594fa181f6e2fca4e1da7504a5fe35dbfbc8cb11c0b4b47813916086L48-R48): The "modifiers" object has been reformatted from having a newline between the opening and closing braces to being on a single line.